### PR TITLE
monkeypatch openapi to force swaggerui to send exploded form params

### DIFF
--- a/api/app/api.py
+++ b/api/app/api.py
@@ -3,6 +3,7 @@
 from datetime import date
 from functools import lru_cache
 
+import fastapi.openapi.utils
 import httpx
 from fastapi import Depends, FastAPI, File, Form, HTTPException, Query, UploadFile
 from loguru import logger
@@ -11,6 +12,11 @@ from sqlmodel import Session, SQLModel, create_engine, select
 
 from app import config, tables
 from app.db_helpers import commit, get_or_create
+from app.patch import get_request_body_with_explode
+
+# monkeypatch to fix swaggerui explode arguments
+fastapi.openapi.utils.get_openapi_operation_request_body = get_request_body_with_explode
+
 
 db_conn_str = "sqlite:///database.sqlite"
 connect_args = {"check_same_thread": False}

--- a/api/app/patch.py
+++ b/api/app/patch.py
@@ -1,0 +1,56 @@
+"""Patch the openapi schema for list form body params to add an encoding field which
+forces swaggerUI to "explode" the params it sends
+
+This is adapted from https://github.com/tiangolo/fastapi/issues/3532#issuecomment-1318097787
+"""
+
+from enum import Enum
+from typing import Any, Dict, Optional, Type, Union
+
+import fastapi.openapi.utils
+from fastapi.openapi.constants import REF_PREFIX
+from pydantic import BaseModel
+from pydantic.fields import ModelField
+from pydantic.schema import field_schema
+
+orig_get_request_body = fastapi.openapi.utils.get_openapi_operation_request_body
+
+
+def get_request_body_with_explode(
+    *,
+    body_field: Optional[ModelField],
+    model_name_map: Dict[Union[Type[BaseModel], Type[Enum]], str],
+) -> Optional[Dict[str, Any]]:
+    """Monkeypatch fastapi's function with this one to enable swaggerui to correctly
+    send "exploded" data
+
+    e.g.:
+    fastapi.openapi.utils.get_openapi_operation_request_body = get_request_body_with_explode
+    """
+
+    original = orig_get_request_body(
+        body_field=body_field, model_name_map=model_name_map
+    )
+    if not original:
+        return original
+
+    content = original.get("content", {})
+    if form_patch := (
+        content.get("application/x-www-form-urlencoded")
+        or content.get("multipart/form-data")
+    ):
+        _, schemas, _ = field_schema(
+            body_field, model_name_map=model_name_map, ref_prefix=REF_PREFIX
+        )
+        # from the body, identify all the "array" properties
+        array_props = []
+        for schema in schemas.values():  # type: Dict[str, Any]
+            for prop, prop_schema in schema.get("properties", {}).items():
+                if prop_schema.get("type") == "array":
+                    array_props.append(prop)
+
+        form_patch["encoding"] = {
+            prop: {"style": "form"} for prop in array_props
+        }  # could include "explode": True but not necessary in swagger-ui
+
+    return original


### PR DESCRIPTION
monkeypatch the openapi schema to force swaggerui to send form body params in "exploded" format, as opposed to CSV.

encoding/form style spec described here:
https://swagger.io/docs/specification/describing-request-body/